### PR TITLE
Remove obsolete example from `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,3 @@ jobs:
         release_id: ${{ steps.create_release.outputs.id }}
 
 ```
-
-A complete workflow building on multiple platforms using this approach can be seen
-[here](https://github.com/ruby/ruby-dev-builder/blob/master/.github/workflows/build.yml).


### PR DESCRIPTION
Since https://github.com/ruby/ruby-dev-builder/commit/ba2497107b28ddd8781fd9a433d22fc432c6b62e, the linked example workflow no longer features this action.